### PR TITLE
изменение внешних ключей

### DIFF
--- a/CityTalk.UserService/Domain/EntityConfigurations/BusinessInformationConfiguration.cs
+++ b/CityTalk.UserService/Domain/EntityConfigurations/BusinessInformationConfiguration.cs
@@ -15,7 +15,7 @@ namespace Domain.EntityConfigurations
             builder.HasIndex(x => x.AccountId).IsUnique(true);
             builder.Property(x => x.AccountId).IsRequired(true);
             builder.HasOne(x => x.Account)
-                .WithOne()
+                .WithOne(x => x.BusinessInformation)
                 .HasForeignKey<BusinessInformation>(x => x.AccountId);
 
             builder.Property(x => x.TIN).IsRequired(true);

--- a/CityTalk.UserService/Domain/EntityConfigurations/ChatUserBindConfiguration.cs
+++ b/CityTalk.UserService/Domain/EntityConfigurations/ChatUserBindConfiguration.cs
@@ -16,7 +16,7 @@ namespace Domain.EntityConfigurations
 
             builder.Property(x => x.ChatId).IsRequired(true);
             builder.HasOne(x => x.Chat)
-                .WithMany()
+                .WithMany(x => x.MemberBinds)
                 .HasForeignKey(x => x.ChatId)
                 .OnDelete(DeleteBehavior.Cascade);
 

--- a/CityTalk.UserService/Domain/EntityConfigurations/OrganizationConfiguration.cs
+++ b/CityTalk.UserService/Domain/EntityConfigurations/OrganizationConfiguration.cs
@@ -14,7 +14,7 @@ namespace Domain.EntityConfigurations
 
             builder.Property(x => x.OwnerId).IsRequired(true);
             builder.HasOne(x => x.Owner)
-                .WithMany()
+                .WithMany(x => x.Organizations)
                 .HasForeignKey(x => x.OwnerId)
                 .OnDelete(DeleteBehavior.Cascade);
 

--- a/CityTalk.UserService/Domain/EntityConfigurations/UserReadMessageConfiguration.cs
+++ b/CityTalk.UserService/Domain/EntityConfigurations/UserReadMessageConfiguration.cs
@@ -21,7 +21,7 @@ namespace Domain.EntityConfigurations
 
             builder.Property(x => x.MessageId).IsRequired(true);
             builder.HasOne(x => x.Message)
-                .WithMany()
+                .WithMany(x => x.WhoRead)
                 .HasForeignKey(x => x.MessageId)
                 .OnDelete(DeleteBehavior.Cascade);
 


### PR DESCRIPTION
Добавлено явное указание полей для связей между сущностями, поскольку происходило дублирование внешних ключей из-за неправильного маппинга